### PR TITLE
fix: final character of string gets cut off

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -34,7 +34,7 @@ const parseText = (text: string, options: ParseOptions): ParseResult => {
 
     let position = 0;
 
-    while (position + 1 < text.length) {
+    while (position + 1 <= text.length) {
         const char = text.charAt(position);
 
         if (char === options.formattingCharacter) {


### PR DESCRIPTION
There is an issue where the final character of the MOTD string in `minecraft-server-util` gets cut off, e.g.:
- Original: `A Minecraft Server`
- Parsed: `A Minecraft Serve`

It seems the while loop in `parse.parseText` does not account for the final character of the string. Changing the comparison operator from `<` to `<=` in the provided condition appears to fix this issue.

Current behaviour:
![image](https://user-images.githubusercontent.com/9079480/144958108-d11a911e-4938-489b-bb7d-5cd3d9fe79de.png)

Fix (applied to `minecraft-motd-util/dist/parse.js`):
![image](https://user-images.githubusercontent.com/9079480/144958185-2a9948b9-1220-414e-85f3-dae75db1c034.png)
