### PR TITLE
fix: #3, and #5

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -87,22 +87,27 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
     const item: ParseItem = result[0];
 
     if (((parent && parseBool(parent.bold)) && !parseBool(chat.bold)) || parseBool(chat.bold)) {
+        chat.bold = 'true';
         item.bold = true;
     }
 
     if (((parent && parseBool(parent.italic)) && !parseBool(chat.italic)) || parseBool(chat.italic)) {
+        chat.italic = 'true';
         item.italics = true;
     }
 
     if (((parent && parseBool(parent.underlined)) && !parseBool(chat.underlined)) || parseBool(chat.underlined)) {
+        chat.underlined = 'true';
         item.underline = true;
     }
 
     if (((parent && parseBool(parent.strikethrough)) && !parseBool(chat.strikethrough)) || parseBool(chat.strikethrough)) {
+        chat.strikethrough = 'true';
         item.strikethrough = true;
     }
 
     if (((parent && parseBool(parent.obfuscated)) && !parseBool(chat.obfuscated)) || parseBool(chat.obfuscated)) {
+        chat.obfuscated = 'true';
         item.obfuscated = true;
     }
 
@@ -110,6 +115,7 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
         item.color = colorLookupNames[chat.color] || chat.color;
     }
     else if (parent?.color) {
+        chat.color = parent.color;
         item.color = colorLookupNames[parent.color] || parent.color;
     }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -130,7 +130,13 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
 
     if (chat.extra) {
         for (const extra of chat.extra) {
-            result.push(...parseChat(extra, options, chat));
+            const extraText = extra.text || extra.translate || '';
+            if (extraText === '' && (!extra.extra || extra.extra.length === 0) && !parent) {
+                result.push({ text: '\n', color: 'white' });
+            }
+            else {
+                result.push(...parseChat(extra, options, chat));
+            }
         }
     }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -107,7 +107,10 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
     }
 
     if (chat.color) {
-        item.color = colorLookupNames[chat.color ?? parent?.color ?? 'white'] || chat.color;
+        item.color = colorLookupNames[chat.color] || chat.color;
+    }
+    else if (parent?.color) {
+        item.color = colorLookupNames[parent.color] || parent.color;
     }
 
     if (chat.extra) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -82,41 +82,49 @@ const parseText = (text: string, options: ParseOptions): ParseResult => {
 };
 
 const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResult => {
-    const result: ParseResult = parseText(chat.text || chat.translate || '', options);
+    const text = chat.text || chat.translate || '';
+    let result: ParseResult;
 
-    const item: ParseItem = result[0];
-
-    if (((parent && parseBool(parent.bold)) && !parseBool(chat.bold)) || parseBool(chat.bold)) {
-        chat.bold = 'true';
-        item.bold = true;
+    if (text === '' && chat.extra && chat.extra.length > 0) {
+        result = [];
     }
+    else {
+        result = parseText(text, options);
 
-    if (((parent && parseBool(parent.italic)) && !parseBool(chat.italic)) || parseBool(chat.italic)) {
-        chat.italic = 'true';
-        item.italics = true;
-    }
+        const item: ParseItem = result[0];
 
-    if (((parent && parseBool(parent.underlined)) && !parseBool(chat.underlined)) || parseBool(chat.underlined)) {
-        chat.underlined = 'true';
-        item.underline = true;
-    }
+        if (((parent && parseBool(parent.bold)) && !parseBool(chat.bold)) || parseBool(chat.bold)) {
+            chat.bold = 'true';
+            item.bold = true;
+        }
 
-    if (((parent && parseBool(parent.strikethrough)) && !parseBool(chat.strikethrough)) || parseBool(chat.strikethrough)) {
-        chat.strikethrough = 'true';
-        item.strikethrough = true;
-    }
+        if (((parent && parseBool(parent.italic)) && !parseBool(chat.italic)) || parseBool(chat.italic)) {
+            chat.italic = 'true';
+            item.italics = true;
+        }
 
-    if (((parent && parseBool(parent.obfuscated)) && !parseBool(chat.obfuscated)) || parseBool(chat.obfuscated)) {
-        chat.obfuscated = 'true';
-        item.obfuscated = true;
-    }
+        if (((parent && parseBool(parent.underlined)) && !parseBool(chat.underlined)) || parseBool(chat.underlined)) {
+            chat.underlined = 'true';
+            item.underline = true;
+        }
 
-    if (chat.color) {
-        item.color = colorLookupNames[chat.color] || chat.color;
-    }
-    else if (parent?.color) {
-        chat.color = parent.color;
-        item.color = colorLookupNames[parent.color] || parent.color;
+        if (((parent && parseBool(parent.strikethrough)) && !parseBool(chat.strikethrough)) || parseBool(chat.strikethrough)) {
+            chat.strikethrough = 'true';
+            item.strikethrough = true;
+        }
+
+        if (((parent && parseBool(parent.obfuscated)) && !parseBool(chat.obfuscated)) || parseBool(chat.obfuscated)) {
+            chat.obfuscated = 'true';
+            item.obfuscated = true;
+        }
+
+        if (chat.color) {
+            item.color = colorLookupNames[chat.color] || chat.color;
+        }
+        else if (parent?.color) {
+            chat.color = parent.color;
+            item.color = colorLookupNames[parent.color] || parent.color;
+        }
     }
 
     if (chat.extra) {
@@ -130,7 +138,8 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
 
 export const parse = (input: Chat | string, options?: ParseOptions): ParseResult => {
     options = Object.assign({
-        formattingCharacter: '\u00A7'
+        formattingCharacter: '\u00A7',
+        includeEmptyText: false
     }, options);
 
     let result;
@@ -149,6 +158,10 @@ export const parse = (input: Chat | string, options?: ParseOptions): ParseResult
         default: {
             throw new Error('Unexpected server MOTD type: ' + typeof input);
         }
+    }
+
+    if (options.includeEmptyText) {
+        return result;
     }
 
     return result.filter((item) => item.text.length > 0);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -82,61 +82,46 @@ const parseText = (text: string, options: ParseOptions): ParseResult => {
 };
 
 const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResult => {
-    const text = chat.text || chat.translate || '';
-    let result: ParseResult;
+    const result: ParseResult = parseText(chat.text || chat.translate || '', options);
+    const item: ParseItem = result[0];
 
-    if (text === '' && chat.extra && chat.extra.length > 0) {
-        result = [];
+    if (((parent && parseBool(parent.bold)) && !parseBool(chat.bold)) || parseBool(chat.bold)) {
+        item.bold = true;
     }
-    else {
-        result = parseText(text, options);
 
-        const item: ParseItem = result[0];
-
-        if (((parent && parseBool(parent.bold)) && !parseBool(chat.bold)) || parseBool(chat.bold)) {
-            item.bold = true;
-        }
-
-        if (((parent && parseBool(parent.italic)) && !parseBool(chat.italic)) || parseBool(chat.italic)) {
-            item.italics = true;
-        }
-
-        if (((parent && parseBool(parent.underlined)) && !parseBool(chat.underlined)) || parseBool(chat.underlined)) {
-            item.underline = true;
-        }
-
-        if (((parent && parseBool(parent.strikethrough)) && !parseBool(chat.strikethrough)) || parseBool(chat.strikethrough)) {
-            item.strikethrough = true;
-        }
-
-        if (((parent && parseBool(parent.obfuscated)) && !parseBool(chat.obfuscated)) || parseBool(chat.obfuscated)) {
-            item.obfuscated = true;
-        }
-
-        if (chat.color) {
-            item.color = colorLookupNames[chat.color] || chat.color;
-        }
-        else if (parent?.color) {
-            item.color = colorLookupNames[parent.color] || parent.color;
-        }
-
-        chat.bold = item.bold ? 'true' : 'false';
-        chat.italic = item.italics ? 'true' : 'false';
-        chat.underlined = item.underline ? 'true' : 'false';
-        chat.strikethrough = item.strikethrough ? 'true' : 'false';
-        chat.obfuscated = item.obfuscated ? 'true' : 'false';
-        chat.color = item.color;
+    if (((parent && parseBool(parent.italic)) && !parseBool(chat.italic)) || parseBool(chat.italic)) {
+        item.italics = true;
     }
+
+    if (((parent && parseBool(parent.underlined)) && !parseBool(chat.underlined)) || parseBool(chat.underlined)) {
+        item.underline = true;
+    }
+
+    if (((parent && parseBool(parent.strikethrough)) && !parseBool(chat.strikethrough)) || parseBool(chat.strikethrough)) {
+        item.strikethrough = true;
+    }
+
+    if (((parent && parseBool(parent.obfuscated)) && !parseBool(chat.obfuscated)) || parseBool(chat.obfuscated)) {
+        item.obfuscated = true;
+    }
+
+    if (chat.color) {
+        item.color = colorLookupNames[chat.color] || chat.color;
+    }
+    else if (parent?.color) {
+        item.color = colorLookupNames[parent.color] || parent.color;
+    }
+
+    chat.bold = item.bold ? 'true' : 'false';
+    chat.italic = item.italics ? 'true' : 'false';
+    chat.underlined = item.underline ? 'true' : 'false';
+    chat.strikethrough = item.strikethrough ? 'true' : 'false';
+    chat.obfuscated = item.obfuscated ? 'true' : 'false';
+    chat.color = item.color;
 
     if (chat.extra) {
         for (const extra of chat.extra) {
-            const extraText = extra.text || extra.translate || '';
-            if (extraText === '' && (!extra.extra || extra.extra.length === 0) && !parent) {
-                result.push({ text: '\n', color: 'white' });
-            }
-            else {
-                result.push(...parseChat(extra, options, chat));
-            }
+            result.push(...parseChat(extra, options, chat));
         }
     }
 
@@ -145,8 +130,7 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
 
 export const parse = (input: Chat | string, options?: ParseOptions): ParseResult => {
     options = Object.assign({
-        formattingCharacter: '\u00A7',
-        includeEmptyText: false
+        formattingCharacter: '\u00A7'
     }, options);
 
     let result;
@@ -165,10 +149,6 @@ export const parse = (input: Chat | string, options?: ParseOptions): ParseResult
         default: {
             throw new Error('Unexpected server MOTD type: ' + typeof input);
         }
-    }
-
-    if (options.includeEmptyText) {
-        return result;
     }
 
     return result.filter((item) => item.text.length > 0);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -94,27 +94,22 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
         const item: ParseItem = result[0];
 
         if (((parent && parseBool(parent.bold)) && !parseBool(chat.bold)) || parseBool(chat.bold)) {
-            chat.bold = 'true';
             item.bold = true;
         }
 
         if (((parent && parseBool(parent.italic)) && !parseBool(chat.italic)) || parseBool(chat.italic)) {
-            chat.italic = 'true';
             item.italics = true;
         }
 
         if (((parent && parseBool(parent.underlined)) && !parseBool(chat.underlined)) || parseBool(chat.underlined)) {
-            chat.underlined = 'true';
             item.underline = true;
         }
 
         if (((parent && parseBool(parent.strikethrough)) && !parseBool(chat.strikethrough)) || parseBool(chat.strikethrough)) {
-            chat.strikethrough = 'true';
             item.strikethrough = true;
         }
 
         if (((parent && parseBool(parent.obfuscated)) && !parseBool(chat.obfuscated)) || parseBool(chat.obfuscated)) {
-            chat.obfuscated = 'true';
             item.obfuscated = true;
         }
 
@@ -122,9 +117,15 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
             item.color = colorLookupNames[chat.color] || chat.color;
         }
         else if (parent?.color) {
-            chat.color = parent.color;
             item.color = colorLookupNames[parent.color] || parent.color;
         }
+
+        if (item.bold) chat.bold = 'true';
+        if (item.italics) chat.italic = 'true';
+        if (item.strikethrough) chat.strikethrough = 'true';
+        if (item.underline) chat.underlined = 'true';
+        if (item.obfuscated) chat.obfuscated = 'true';
+        if (item.color) chat.color = item.color;
     }
 
     if (chat.extra) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -120,12 +120,12 @@ const parseChat = (chat: Chat, options: ParseOptions, parent?: Chat): ParseResul
             item.color = colorLookupNames[parent.color] || parent.color;
         }
 
-        if (item.bold) chat.bold = 'true';
-        if (item.italics) chat.italic = 'true';
-        if (item.strikethrough) chat.strikethrough = 'true';
-        if (item.underline) chat.underlined = 'true';
-        if (item.obfuscated) chat.obfuscated = 'true';
-        if (item.color) chat.color = item.color;
+        chat.bold = item.bold ? 'true' : 'false';
+        chat.italic = item.italics ? 'true' : 'false';
+        chat.underlined = item.underline ? 'true' : 'false';
+        chat.strikethrough = item.strikethrough ? 'true' : 'false';
+        chat.obfuscated = item.obfuscated ? 'true' : 'false';
+        chat.color = item.color;
     }
 
     if (chat.extra) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,7 @@ export interface ParseItem {
 export type ParseResult = ParseItem[];
 
 export interface ParseOptions {
-    formattingCharacter?: string,
-    includeEmptyText?: boolean
+    formattingCharacter?: string
 }
 
 export interface CleanOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,8 @@ export interface ParseItem {
 export type ParseResult = ParseItem[];
 
 export interface ParseOptions {
-    formattingCharacter?: string
+    formattingCharacter?: string,
+    includeEmptyText?: boolean
 }
 
 export interface CleanOptions {


### PR DESCRIPTION
This fixes the following issues:
- https://github.com/PassTheMayo/minecraft-motd-util/issues/3
  * `parent.color` is now properly checked for
- https://github.com/PassTheMayo/minecraft-motd-util/issues/5
  * children's formatters now properly inherit from more than just the direct parent